### PR TITLE
[Enhancement] Voice control links availability for LabelTextView

### DIFF
--- a/Sources/Cocoa/Extensions/UITextView+Extensions.swift
+++ b/Sources/Cocoa/Extensions/UITextView+Extensions.swift
@@ -33,4 +33,35 @@ extension UITextView {
         }
         set { textContainer.maximumNumberOfLines = newValue }
     }
+
+    func textRange(from range: NSRange) -> UITextRange? {
+        guard
+            let start = position(from: beginningOfDocument, offset: range.location),
+            let end = position(from: start, offset: range.length)
+        else {
+            return nil
+        }
+        return self.textRange(from: start, to: end)
+    }
+
+    /// Returns `UIAccessibilityElement` for all links inside current instance
+    /// it was given when created.
+    public var linkAccessibilityElements: [UIAccessibilityElement] {
+        var linkElements: [UIAccessibilityElement] = []
+        attributedText.enumerateAttribute(.link, in: NSRange(0..<attributedText.length)) { value, range, _ in
+            guard value != nil else {
+                return
+            }
+            let element = UIAccessibilityElement(accessibilityContainer: self)
+            element.accessibilityTraits = .link
+            element.accessibilityValue = (value as? URL)?.absoluteString
+            if let textRange = textRange(from: range) {
+                element.accessibilityFrameInContainerSpace = firstRect(for: textRange)
+                element.accessibilityLabel = self.text(in: textRange)
+            }
+            linkElements.append(element)
+        }
+
+        return linkElements
+    }
 }


### PR DESCRIPTION
### Motivation
I am proposing for Voice Control to use the wrapper as UIView and compute accessible elements - this is what iOS 13 is not doing correctly currently and we are trying to fix it by this PR.

### Discussion
After various testing of UITextView component I found out: 

- `accessibilityElements` are called only when there is more than just one link inside the component
- the variable `accessibilityElements` is not reacting to `overriding`
- adding subview to UITextView with auto layout does not calculate the correct frame (more in https://github.com/zmian/Xcore/pull/79#discussion_r497473676)

For Voice Over we will disable this behaviour to not interact with flows, we are currently supporting.

### Testing
I have tested this with iOS 13 and both VoiceControl and VoiceOver - turning on/off during the flow or continually using one or two of the mentioned accessibility features. 
