### PR TITLE
[Enhancement] ImageAssetIdentifier optional init

### DIFF
--- a/Sources/Cocoa/Components/Assets/ImageAssetIdentifier.swift
+++ b/Sources/Cocoa/Components/Assets/ImageAssetIdentifier.swift
@@ -67,7 +67,7 @@ extension UIImage {
 // MARK: - UIImageView
 
 extension UIImageView {
-    public convenience init(assetIdentifier: ImageAssetIdentifier) {
+    public convenience init(assetIdentifier: ImageAssetIdentifier?) {
         self.init()
         setImage(assetIdentifier) { [weak self] image in
             guard let strongSelf = self else { return }


### PR DESCRIPTION
There is no need to restrict the ImageAssetIdentifier to non-optional value for init of UIImageView if children can work with optional.