### PR TITLE
[Fix] Quick scrolling on carrouselCollectionView

### DIFF
--- a/Example/ViewControllers/Showcase/CarouselViewController.swift
+++ b/Example/ViewControllers/Showcase/CarouselViewController.swift
@@ -21,7 +21,9 @@ final class CarouselViewController: UIViewController {
     private let items = [
         Item(title: "First Item", image: r(.blueJay)),
         Item(title: "Second Item", image: r(.blueJay)),
-        Item(title: "Third Item", image: r(.blueJay))
+        Item(title: "Third Item", image: r(.blueJay)),
+        Item(title: "Fourth Item", image: r(.blueJay)),
+        Item(title: "Fifth Item", image: r(.blueJay))
     ]
 
     private let carouselView = CarouselView<ItemCell>().apply {

--- a/Sources/Cocoa/Components/CarouselView/CarouselCollectionView.swift
+++ b/Sources/Cocoa/Components/CarouselView/CarouselCollectionView.swift
@@ -214,6 +214,8 @@ final class CarouselCollectionView
             return
         }
 
+        adjustInfiniteScrollContentOffset()
+
         previousIndex = currentIndex
         if !ignoreScrollEventsCallbacks {
             didChangeCurrentItem?(currentIndex, item)
@@ -241,6 +243,8 @@ final class CarouselCollectionView
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         guard let autoScrollTimer = autoScrollTimer else { return }
         startAutoScrolling(autoScrollTimer.timeInterval)
+
+        adjustInfiniteScrollContentOffset()
     }
 
     private func item(at index: Int) -> Cell.Model? {
@@ -319,6 +323,7 @@ extension CarouselCollectionView {
             return
         }
 
+        adjustInfiniteScrollContentOffset()
         setCurrentIndex(currentIndex + 1)
     }
 

--- a/Sources/Cocoa/Components/CarouselView/CarouselCollectionView.swift
+++ b/Sources/Cocoa/Components/CarouselView/CarouselCollectionView.swift
@@ -194,6 +194,8 @@ final class CarouselCollectionView
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        adjustInfiniteScrollContentOffset()
+
         guard !ignoreScrollEventsCallbacks else { return }
         didScroll?(currentIndex, previousIndex, scrollView)
 
@@ -211,8 +213,6 @@ final class CarouselCollectionView
         guard let item = item(at: currentIndex) else {
             return
         }
-
-        adjustInfiniteScrollContentOffset()
 
         previousIndex = currentIndex
         if !ignoreScrollEventsCallbacks {
@@ -315,7 +315,6 @@ extension CarouselCollectionView {
             return
         }
 
-        adjustInfiniteScrollContentOffset()
         setCurrentIndex(currentIndex + 1)
     }
 
@@ -358,11 +357,11 @@ extension CarouselCollectionView {
     private func adjustInfiniteScrollContentOffset() {
         guard style == .infiniteScroll else { return }
         // If we are standing on the begining or end of the scroll view we need to place
-        // the offset in the same spot (page) but  with a next and a previous page
+        // the offset in the same spot (page) but with a next and a previous page
         // within the scroll
         let lastPage = numberOfItems(inSection: 0)
         let lastPageOffset = CGFloat(lastPage - 1) * bounds.width
-        if contentOffset.x == lastPageOffset || contentOffset.x == 0 {
+        if contentOffset.x >= lastPageOffset || contentOffset.x <= 0 {
             contentOffset = CGPoint(x: offset(forPage: currentIndex), y: 0)
         }
     }

--- a/Sources/Cocoa/Components/CarouselView/CarouselCollectionView.swift
+++ b/Sources/Cocoa/Components/CarouselView/CarouselCollectionView.swift
@@ -252,6 +252,10 @@ final class CarouselCollectionView
     func setCurrentIndex(_ index: Int, animated: Bool = true, completion: (() -> Void)? = nil) {
         guard currentIndex != index else { return }
 
+        if style == .default, index > (numberOfItems - 1) || index < 0 {
+            return
+        }
+
         layoutIfNeeded()
         CATransaction.animation({
             ignoreScrollEventsCallbacks = true


### PR DESCRIPTION
**Motivation:**
Currently, when the user starts scroll between pages quickly he will get stuck at the end of scroll view (In our case he is going by pages -> 0, 1, 2, 3, 0, 0, 0, 0. So he will stay on the page with an index 0.

**Issue:**
Scroll view `contentOffset` is set only when the user's scrolling is finished - because of that the scrolling does not continue but stays on the same page while the user is still scrolling.

**FIX**
We will calculate and set `contentOffset` when it's needed by extending ranges from qual to grarterOrEqual/lessOrEqual and set offset while scrollView is scrolling.

**Other**
I would recommend testing this issue on the device and with more than just 3 items inside carouselView