### PR TITLE
[FIX] Re-add swizzle for UITableViewCell.setHighlighted(_:animated:)

### DIFF
--- a/Sources/Cocoa/Components/Swizzle/SwizzleManager.swift
+++ b/Sources/Cocoa/Components/Swizzle/SwizzleManager.swift
@@ -99,6 +99,10 @@ final public class SwizzleManager {
             UISearchBar.runOnceSwapSelectors()
         }
 
+        if options.contains(.tableViewCell) {
+            UITableViewCell.runOnceSwapSelectors()
+        }
+
         if options.contains(.collectionViewCell) {
             UICollectionViewCell.runOnceSwapSelectors()
         }
@@ -129,10 +133,11 @@ extension SwizzleManager {
         public static let textView = Self(rawValue: 1 << 4)
         public static let imageView = Self(rawValue: 1 << 5)
         public static let searchBar = Self(rawValue: 1 << 6)
-        public static let collectionViewCell = Self(rawValue: 1 << 7)
-        public static let viewController = Self(rawValue: 1 << 8)
-        public static let userContentController = Self(rawValue: 1 << 9)
-        public static let chrome = Self(rawValue: 1 << 10)
+        public static let tableViewCell = Self(rawValue: 1 << 7)
+        public static let collectionViewCell = Self(rawValue: 1 << 8)
+        public static let viewController = Self(rawValue: 1 << 9)
+        public static let userContentController = Self(rawValue: 1 << 10)
+        public static let chrome = Self(rawValue: 1 << 11)
         public static let all: Self = [
             view,
             button,
@@ -141,6 +146,7 @@ extension SwizzleManager {
             textView,
             imageView,
             searchBar,
+            tableViewCell,
             collectionViewCell,
             viewController,
             userContentController,

--- a/Sources/Cocoa/Extensions/UITableView/UITableViewCell+Extensions.swift
+++ b/Sources/Cocoa/Extensions/UITableView/UITableViewCell+Extensions.swift
@@ -69,10 +69,10 @@ extension UITableViewCell {
     }
 }
 
-// MARK: - Swizzled Methods
+// MARK: - Highlighted Background Color
 
 extension UITableViewCell {
-    func _setHighlighted(_ highlighted: Bool, animated: Bool) {
+    @objc func swizzled_setHighlighted(_ highlighted: Bool, animated: Bool) {
         highlightedAnimation.animate(highlightedAnimationView, isHighlighted: highlighted)
 
         guard let highlightedBackgroundColor = highlightedBackgroundColor else {
@@ -89,5 +89,17 @@ extension UITableViewCell {
         UIView.animateFromCurrentState(withDuration: animated ? 0.15 : 0) {
             self.highlightedBackgroundColorView.backgroundColor = newBackgroundColor
         }
+    }
+}
+
+// MARK: - Swizzle
+
+extension UITableViewCell {
+    static func runOnceSwapSelectors() {
+        swizzle(
+            UITableViewCell.self,
+            originalSelector: #selector(UITableViewCell.setHighlighted(_:animated:)),
+            swizzledSelector: #selector(UITableViewCell.swizzled_setHighlighted(_:animated:))
+        )
     }
 }


### PR DESCRIPTION
I am not sure why this was missing in the first place. The highlighting inside UITableViewCell was not working at all.