### PR TITLE
Fix bug on View+Popup

### DIFF
--- a/Sources/Xcore/SwiftUI/Components/Popup/View+Popup.swift
+++ b/Sources/Xcore/SwiftUI/Components/Popup/View+Popup.swift
@@ -176,7 +176,14 @@ extension View {
         @ViewBuilder actions: @escaping () -> A,
         onDismiss: (() -> Void)? = nil
     ) -> some View where A: View, S1: StringProtocol, S2: StringProtocol {
-        popup(Text(title), message: message.map { Text($0) }, isPresented: isPresented, actions: actions)
+        popup(
+            Text(title),
+            message: message.map { Text($0) },
+            isPresented: isPresented,
+            dismissMethods: dismissMethods,
+            actions: actions,
+            onDismiss: onDismiss
+        )
     }
 }
 


### PR DESCRIPTION
The `dismissMethods` & `onDismiss` params were ignored on one of the creation methods.