### PR TITLE
Fix compareAmount usage for money abbreviation check

### DIFF
--- a/Sources/Xcore/Cocoa/Components/Currency/Money/Money+Components+Style.swift
+++ b/Sources/Xcore/Cocoa/Components/Currency/Money/Money+Components+Style.swift
@@ -133,7 +133,7 @@ extension Money.Components.Style {
             let compareAmount = thresholdAbs ? abs(amount) : amount
 
             guard
-                amount >= 1000,
+                compareAmount >= 1000,
                 compareAmount >= threshold,
                 let amountValue = Double(exactly: NSDecimalNumber(decimal: amount.rounded(fractionDigits: 2))),
                 let thresholdValue = Double(exactly: NSDecimalNumber(decimal: threshold))


### PR DESCRIPTION
Use `compareAmount` instead of `amount` to check if value should be abbreviated.
Otherwise negative amounts will never be abbreviated.

(address issue on Financials Tile, for Cloudfare stock)