### PR TITLE
Fix string secret SHA256 derivation in Crypt

### DIFF
--- a/Sources/Xcore/Swift/Components/Encoding/Crypt.swift
+++ b/Sources/Xcore/Swift/Components/Encoding/Crypt.swift
@@ -12,26 +12,6 @@ public enum Crypt: Sendable {
         case deobfuscationFailure
         case urlNotFound
     }
-
-    private static func contentsData(from url: URL?) throws -> Data {
-        guard let url else {
-            throw Error.urlNotFound
-        }
-
-        return try Data(contentsOf: url)
-    }
-
-    private static func secretData(from secret: String) -> Data {
-        Data(secret.utf8).sha256()
-    }
-
-    private static func symmetricKey(from secret: some ContiguousBytes) -> SymmetricKey {
-        SymmetricKey(data: secret)
-    }
-
-    private static func symmetricKey(fromSecret secret: String) -> SymmetricKey {
-        SymmetricKey(data: secretData(from: secret))
-    }
 }
 
 // MARK: - Decrypt
@@ -70,7 +50,11 @@ extension Crypt {
     ///   as the correct key is used and authentication succeeds. The call throws an
     ///   error if decryption or authentication fail.
     public static func decrypt(contentsOf url: URL?, secret: String) throws -> Data {
-        try decrypt(try contentsData(from: url), secret: secret)
+        guard let url else {
+            throw Error.urlNotFound
+        }
+
+        return try decrypt(try Data(contentsOf: url), secret: secret)
     }
 
     /// Decrypts the content at the given url and verifies its authenticity.
@@ -82,7 +66,11 @@ extension Crypt {
     ///   as the correct key is used and authentication succeeds. The call throws an
     ///   error if decryption or authentication fail.
     public static func decrypt(contentsOf url: URL?, secret: some ContiguousBytes) throws -> Data {
-        try decrypt(try contentsData(from: url), secret: secret)
+        guard let url else {
+            throw Error.urlNotFound
+        }
+
+        return try decrypt(try Data(contentsOf: url), secret: secret)
     }
 
     /// Decrypts the data and verifies its authenticity.
@@ -94,7 +82,7 @@ extension Crypt {
     ///   as the correct key is used and authentication succeeds. The call throws an
     ///   error if decryption or authentication fail.
     public static func decrypt(_ data: Data, secret: String) throws -> Data {
-        try ChaChaPoly.open(.init(combined: data), using: symmetricKey(fromSecret: secret))
+        try decrypt(data, secret: secret.sha256Data())
     }
 
     /// Decrypts the data and verifies its authenticity.
@@ -106,7 +94,8 @@ extension Crypt {
     ///   as the correct key is used and authentication succeeds. The call throws an
     ///   error if decryption or authentication fail.
     public static func decrypt(_ data: Data, secret: some ContiguousBytes) throws -> Data {
-        try ChaChaPoly.open(.init(combined: data), using: symmetricKey(from: secret))
+        let key = SymmetricKey(data: secret)
+        return try ChaChaPoly.open(.init(combined: data), using: key)
     }
 }
 
@@ -139,22 +128,30 @@ extension Crypt {
     /// authentication tag.
     ///
     /// - Parameters:
-    ///   - url: The url of the content to encrypt.
+    ///   - path: The url of the content to encrypt.
     ///   - secret: A cryptographic key used to encrypt the data.
     /// - Returns: The encrypted data.
     public static func encrypt(contentsOf url: URL?, secret: String) throws -> Data {
-        try encrypt(try contentsData(from: url), secret: secret)
+        guard let url else {
+            throw Error.urlNotFound
+        }
+
+        return try encrypt(try Data(contentsOf: url), secret: secret)
     }
 
     /// Secures the given plaintext content at the given url with encryption and an
     /// authentication tag.
     ///
     /// - Parameters:
-    ///   - url: The url of the content to encrypt.
+    ///   - path: The url of the content to encrypt.
     ///   - secret: A cryptographic key used to encrypt the data.
     /// - Returns: The encrypted data.
     public static func encrypt(contentsOf url: URL?, secret: some ContiguousBytes) throws -> Data {
-        try encrypt(try contentsData(from: url), secret: secret)
+        guard let url else {
+            throw Error.urlNotFound
+        }
+
+        return try encrypt(try Data(contentsOf: url), secret: secret)
     }
 
     /// Secures the given plaintext data with encryption and an authentication tag.
@@ -164,7 +161,7 @@ extension Crypt {
     ///   - secret: A cryptographic key used to encrypt the data.
     /// - Returns: The encrypted data.
     public static func encrypt(_ data: Data, secret: String) throws -> Data {
-        try ChaChaPoly.seal(data, using: symmetricKey(fromSecret: secret)).combined
+        try encrypt(data, secret: secret.sha256Data())
     }
 
     /// Secures the given plaintext data with encryption and an authentication tag.
@@ -174,7 +171,8 @@ extension Crypt {
     ///   - secret: A cryptographic key used to encrypt the data.
     /// - Returns: The encrypted data.
     public static func encrypt(_ data: Data, secret: some ContiguousBytes) throws -> Data {
-        try ChaChaPoly.seal(data, using: symmetricKey(from: secret)).combined
+        let key = SymmetricKey(data: secret)
+        return try ChaChaPoly.seal(data, using: key).combined
     }
 }
 
@@ -188,7 +186,7 @@ extension Crypt {
     ///   - secret: Secret for obfuscation.
     /// - Returns: Obfuscated value in an array of `UInt8`.
     public static func obfuscate(_ string: String, secret: String) -> [UInt8] {
-        obfuscate(string, secret: Array(secretData(from: secret)))
+        obfuscate(string, secret: Array(secret.sha256Data()))
     }
 
     /// Obfuscates a given string with secret.
@@ -222,7 +220,7 @@ extension Crypt {
     ///   - secret: The secret that was used during obfucation.
     /// - Returns: Deobfuscated value of given obfuscated value.
     public static func deobfuscate(_ value: [UInt8], secret: String) throws -> String {
-        try deobfuscateString(value, secret: Array(secretData(from: secret)))
+        try deobfuscateString(value, secret: Array(secret.sha256Data()))
     }
 
     /// Deobfucates a previously obfuscated value.
@@ -274,5 +272,11 @@ extension Crypt {
     /// least one character from each set being present.
     public static func generateRandomPassword() -> String {
         SecCreateSharedWebCredentialPassword()! as String
+    }
+}
+
+extension String {
+    fileprivate func sha256Data() -> Data {
+        Data(utf8).sha256()
     }
 }

--- a/Sources/Xcore/Swift/Components/Encoding/Crypt.swift
+++ b/Sources/Xcore/Swift/Components/Encoding/Crypt.swift
@@ -12,6 +12,26 @@ public enum Crypt: Sendable {
         case deobfuscationFailure
         case urlNotFound
     }
+
+    private static func contentsData(from url: URL?) throws -> Data {
+        guard let url else {
+            throw Error.urlNotFound
+        }
+
+        return try Data(contentsOf: url)
+    }
+
+    private static func secretData(from secret: String) -> Data {
+        Data(secret.utf8).sha256()
+    }
+
+    private static func symmetricKey(from secret: some ContiguousBytes) -> SymmetricKey {
+        SymmetricKey(data: secret)
+    }
+
+    private static func symmetricKey(fromSecret secret: String) -> SymmetricKey {
+        SymmetricKey(data: secretData(from: secret))
+    }
 }
 
 // MARK: - Decrypt
@@ -50,11 +70,7 @@ extension Crypt {
     ///   as the correct key is used and authentication succeeds. The call throws an
     ///   error if decryption or authentication fail.
     public static func decrypt(contentsOf url: URL?, secret: String) throws -> Data {
-        guard let url else {
-            throw Error.urlNotFound
-        }
-
-        return try decrypt(try Data(contentsOf: url), secret: secret)
+        try decrypt(try contentsData(from: url), secret: secret)
     }
 
     /// Decrypts the content at the given url and verifies its authenticity.
@@ -66,11 +82,7 @@ extension Crypt {
     ///   as the correct key is used and authentication succeeds. The call throws an
     ///   error if decryption or authentication fail.
     public static func decrypt(contentsOf url: URL?, secret: some ContiguousBytes) throws -> Data {
-        guard let url else {
-            throw Error.urlNotFound
-        }
-
-        return try decrypt(try Data(contentsOf: url), secret: secret)
+        try decrypt(try contentsData(from: url), secret: secret)
     }
 
     /// Decrypts the data and verifies its authenticity.
@@ -82,7 +94,7 @@ extension Crypt {
     ///   as the correct key is used and authentication succeeds. The call throws an
     ///   error if decryption or authentication fail.
     public static func decrypt(_ data: Data, secret: String) throws -> Data {
-        try decrypt(data, secret: secret.sha256Data())
+        try ChaChaPoly.open(.init(combined: data), using: symmetricKey(fromSecret: secret))
     }
 
     /// Decrypts the data and verifies its authenticity.
@@ -94,8 +106,7 @@ extension Crypt {
     ///   as the correct key is used and authentication succeeds. The call throws an
     ///   error if decryption or authentication fail.
     public static func decrypt(_ data: Data, secret: some ContiguousBytes) throws -> Data {
-        let key = SymmetricKey(data: secret)
-        return try ChaChaPoly.open(.init(combined: data), using: key)
+        try ChaChaPoly.open(.init(combined: data), using: symmetricKey(from: secret))
     }
 }
 
@@ -128,30 +139,22 @@ extension Crypt {
     /// authentication tag.
     ///
     /// - Parameters:
-    ///   - path: The url of the content to encrypt.
+    ///   - url: The url of the content to encrypt.
     ///   - secret: A cryptographic key used to encrypt the data.
     /// - Returns: The encrypted data.
     public static func encrypt(contentsOf url: URL?, secret: String) throws -> Data {
-        guard let url else {
-            throw Error.urlNotFound
-        }
-
-        return try encrypt(try Data(contentsOf: url), secret: secret)
+        try encrypt(try contentsData(from: url), secret: secret)
     }
 
     /// Secures the given plaintext content at the given url with encryption and an
     /// authentication tag.
     ///
     /// - Parameters:
-    ///   - path: The url of the content to encrypt.
+    ///   - url: The url of the content to encrypt.
     ///   - secret: A cryptographic key used to encrypt the data.
     /// - Returns: The encrypted data.
     public static func encrypt(contentsOf url: URL?, secret: some ContiguousBytes) throws -> Data {
-        guard let url else {
-            throw Error.urlNotFound
-        }
-
-        return try encrypt(try Data(contentsOf: url), secret: secret)
+        try encrypt(try contentsData(from: url), secret: secret)
     }
 
     /// Secures the given plaintext data with encryption and an authentication tag.
@@ -161,7 +164,7 @@ extension Crypt {
     ///   - secret: A cryptographic key used to encrypt the data.
     /// - Returns: The encrypted data.
     public static func encrypt(_ data: Data, secret: String) throws -> Data {
-        try encrypt(data, secret: secret.sha256Data())
+        try ChaChaPoly.seal(data, using: symmetricKey(fromSecret: secret)).combined
     }
 
     /// Secures the given plaintext data with encryption and an authentication tag.
@@ -171,8 +174,7 @@ extension Crypt {
     ///   - secret: A cryptographic key used to encrypt the data.
     /// - Returns: The encrypted data.
     public static func encrypt(_ data: Data, secret: some ContiguousBytes) throws -> Data {
-        let key = SymmetricKey(data: secret)
-        return try ChaChaPoly.seal(data, using: key).combined
+        try ChaChaPoly.seal(data, using: symmetricKey(from: secret)).combined
     }
 }
 
@@ -186,7 +188,7 @@ extension Crypt {
     ///   - secret: Secret for obfuscation.
     /// - Returns: Obfuscated value in an array of `UInt8`.
     public static func obfuscate(_ string: String, secret: String) -> [UInt8] {
-        obfuscate(string, secret: Array(secret.sha256Data()))
+        obfuscate(string, secret: Array(secretData(from: secret)))
     }
 
     /// Obfuscates a given string with secret.
@@ -220,7 +222,7 @@ extension Crypt {
     ///   - secret: The secret that was used during obfucation.
     /// - Returns: Deobfuscated value of given obfuscated value.
     public static func deobfuscate(_ value: [UInt8], secret: String) throws -> String {
-        try deobfuscateString(value, secret: Array(secret.sha256Data()))
+        try deobfuscateString(value, secret: Array(secretData(from: secret)))
     }
 
     /// Deobfucates a previously obfuscated value.
@@ -272,11 +274,5 @@ extension Crypt {
     /// least one character from each set being present.
     public static func generateRandomPassword() -> String {
         SecCreateSharedWebCredentialPassword()! as String
-    }
-}
-
-extension String {
-    fileprivate func sha256Data() -> Data {
-        Data(utf8).base64EncodedData().sha256()
     }
 }

--- a/Tests/XcoreTests/CryptTests.swift
+++ b/Tests/XcoreTests/CryptTests.swift
@@ -77,4 +77,15 @@ struct CryptTests {
             try Crypt.decrypt(encryptedMessage, secret: incorrectSecret)
         }
     }
+
+    @Test
+    func stringSecretUsesSha256OfUtf8() throws {
+        let secret = "my-secret"
+        let message = Data("Hello World".utf8)
+
+        let encryptedMessage = try Crypt.encrypt(message, secret: secret)
+        let decryptedMessage = try Crypt.decrypt(encryptedMessage, secret: Data(secret.utf8).sha256())
+
+        #expect(message == decryptedMessage)
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reverted the private helper refactor (`contentsData`, `secretData`, `symmetricKey`). The original encrypt/decrypt/obfuscate structure is restored.

The only change is in the existing `String.sha256Data()` extension — string secrets now derive keys via SHA256 of UTF-8 bytes instead of SHA256 of the base64 encoding.

## Breaking change

String-based encrypt/decrypt/obfuscate output differs from the old base64-then-SHA256 behavior. Existing payloads encrypted with string secrets need re-encryption.

## Test plan

- [ ] `make test TEST_ONLY=XcoreTests/CryptTests`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

