### PR TITLE
Document intentional single-module architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,61 +77,13 @@ Test case 'URLTests/resolvingRedirectedLink()' passed (12.001 seconds)
 - For SwiftUI and concurrency warnings, prefer a minimal fix that matches the
   framework API contract instead of adding unsafe workarounds.
 
-## Architecture: Single-Module Design
+## Package Layout
 
-Xcore intentionally ships as **one Swift package target** (`Xcore`) and **one
-library product** (`import Xcore`). Do not propose splitting the package into
-submodules (for example `XcoreCore`, `XcoreSwiftUI`, `XcoreUIKit`) unless there
-is measured, repo-specific pain — not as a default refactor suggestion.
+Xcore is one Swift package target: `import Xcore`. Folders (`Swift/`, `SwiftUI/`,
+`Cocoa/`) organize code; they are not separate modules.
 
-### Why one module
-
-- **Single import** matches how the library is documented and consumed.
-- **Folder layout already separates concerns** — `Sources/Xcore/Swift/`,
-  `Sources/Xcore/SwiftUI/`, and `Sources/Xcore/Cocoa/` organize code without
-  package-boundary overhead.
-- **No current compile-time crisis** — the target is ~400 Swift sources; clean
-  and incremental builds have been acceptable in practice on Xcode 26+.
-  Splitting adds cross-target visibility rules, duplicate public surface
-  decisions, and migration cost for little gain unless build times regress
-  measurably.
-- **This is a utility kit, not a tiered SDK** — consumers adopt Xcore as a
-  whole; optional sub-products would add API and release complexity without a
-  stated requirement.
-
-### Binary size (fact check)
-
-Do **not** recommend module splitting to reduce app binary size.
-
-When an app links Xcore, **dead code stripping** (link-time, enabled by default
-for Release app targets) removes unreferenced machine code from the linked
-result. Unused APIs from Xcore are not a reason, by themselves, to split the
-package.
-
-Nuances worth knowing (so advice stays accurate):
-
-- Stripping happens at **link time in the app**, based on what the app actually
-  references — not because Xcore is split into multiple targets.
-- Swift **`public`** symbols are treated more conservatively than `internal`
-  symbols at link time; Apple has been improving link-time internalization for
-  static linking. Even so, splitting Xcore into multiple modules does not change
-  the basic model for an app that imports the full library.
-- **SPM dependencies** (`SDWebImage`, `KeychainAccess`, etc.) are declared on the
-  Xcore package. Internal target splits do not remove those dependencies unless
-  separate public products with different dependency lists are introduced — that
-  is a much larger product decision, not a routine refactor.
-- If Xcore were distributed as a **dynamic framework**, the framework binary is
-  shipped as a unit; that packaging choice is separate from how many targets exist
-  inside the repo.
-
-### When splitting would be worth revisiting
-
-Only if concrete, measured problems appear, such as:
-
-- Clean or incremental build times become a recurring bottleneck on real
-  hardware (profile with `xcodebuild` timing before proposing splits).
-- A **new public product** is required (for example a core-only library with no
-  UIKit/SwiftUI dependencies) with an explicit consumer and release plan.
-- Enforced layering cannot be maintained with folders and code review alone.
-
-Until then, treat the monolithic module as **intentional design**, not tech debt.
+- Do not propose splitting into submodules as a default refactor.
+- Builds are fast enough for this repo; link-time dead code stripping keeps
+  unused APIs out of app binaries.
+- Revisit splitting only for measured build-time pain or an explicit new public
+  product requirement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,62 @@ Test case 'URLTests/resolvingRedirectedLink()' passed (12.001 seconds)
 - Preserve existing public API shape when possible.
 - For SwiftUI and concurrency warnings, prefer a minimal fix that matches the
   framework API contract instead of adding unsafe workarounds.
+
+## Architecture: Single-Module Design
+
+Xcore intentionally ships as **one Swift package target** (`Xcore`) and **one
+library product** (`import Xcore`). Do not propose splitting the package into
+submodules (for example `XcoreCore`, `XcoreSwiftUI`, `XcoreUIKit`) unless there
+is measured, repo-specific pain — not as a default refactor suggestion.
+
+### Why one module
+
+- **Single import** matches how the library is documented and consumed.
+- **Folder layout already separates concerns** — `Sources/Xcore/Swift/`,
+  `Sources/Xcore/SwiftUI/`, and `Sources/Xcore/Cocoa/` organize code without
+  package-boundary overhead.
+- **No current compile-time crisis** — the target is ~400 Swift sources; clean
+  and incremental builds have been acceptable in practice on Xcode 26+.
+  Splitting adds cross-target visibility rules, duplicate public surface
+  decisions, and migration cost for little gain unless build times regress
+  measurably.
+- **This is a utility kit, not a tiered SDK** — consumers adopt Xcore as a
+  whole; optional sub-products would add API and release complexity without a
+  stated requirement.
+
+### Binary size (fact check)
+
+Do **not** recommend module splitting to reduce app binary size.
+
+When an app links Xcore, **dead code stripping** (link-time, enabled by default
+for Release app targets) removes unreferenced machine code from the linked
+result. Unused APIs from Xcore are not a reason, by themselves, to split the
+package.
+
+Nuances worth knowing (so advice stays accurate):
+
+- Stripping happens at **link time in the app**, based on what the app actually
+  references — not because Xcore is split into multiple targets.
+- Swift **`public`** symbols are treated more conservatively than `internal`
+  symbols at link time; Apple has been improving link-time internalization for
+  static linking. Even so, splitting Xcore into multiple modules does not change
+  the basic model for an app that imports the full library.
+- **SPM dependencies** (`SDWebImage`, `KeychainAccess`, etc.) are declared on the
+  Xcore package. Internal target splits do not remove those dependencies unless
+  separate public products with different dependency lists are introduced — that
+  is a much larger product decision, not a routine refactor.
+- If Xcore were distributed as a **dynamic framework**, the framework binary is
+  shipped as a unit; that packaging choice is separate from how many targets exist
+  inside the repo.
+
+### When splitting would be worth revisiting
+
+Only if concrete, measured problems appear, such as:
+
+- Clean or incremental build times become a recurring bottleneck on real
+  hardware (profile with `xcodebuild` timing before proposing splits).
+- A **new public product** is required (for example a core-only library with no
+  UIKit/SwiftUI dependencies) with an explicit consumer and release plan.
+- Enforced layering cannot be maintained with folders and code review alone.
+
+Until then, treat the monolithic module as **intentional design**, not tech debt.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Xcore is a collection of hundreds of Swift extensions and components designed to
 ## Contents
 
 - [Requirements](#requirements)
+- [Architecture](#architecture)
 - [Makefile](#makefile)
 - [Installation](#installation)
 
@@ -19,6 +20,16 @@ Xcore is a collection of hundreds of Swift extensions and components designed to
 - iOS 26.0+
 - Xcode 26.0+
 - Swift 6.3+
+
+## Architecture
+
+Xcore is a **single Swift module** (`import Xcore`). Source is organized by
+folder (`Swift/`, `SwiftUI/`, `Cocoa/`), but the package is not split into
+submodules by design.
+
+Rationale — including notes on binary size, compile time, and when (if ever) to
+revisit splitting — is documented in [`AGENTS.md`](AGENTS.md#architecture-single-module-design)
+for contributors and agents.
 
 **Additional Requirements**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Xcore is a collection of hundreds of Swift extensions and components designed to
 ## Contents
 
 - [Requirements](#requirements)
-- [Architecture](#architecture)
 - [Makefile](#makefile)
 - [Installation](#installation)
 
@@ -20,16 +19,6 @@ Xcore is a collection of hundreds of Swift extensions and components designed to
 - iOS 26.0+
 - Xcode 26.0+
 - Swift 6.3+
-
-## Architecture
-
-Xcore is a **single Swift module** (`import Xcore`). Source is organized by
-folder (`Swift/`, `SwiftUI/`, `Cocoa/`), but the package is not split into
-submodules by design.
-
-Rationale — including notes on binary size, compile time, and when (if ever) to
-revisit splitting — is documented in [`AGENTS.md`](AGENTS.md#architecture-single-module-design)
-for contributors and agents.
 
 **Additional Requirements**
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a short **Package Layout** section to `AGENTS.md` — same style as the rest of that file: decision first, three bullets, no essay.

## Test plan

- [x] Documentation only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

