### PR TITLE
Add platform and API standards to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,22 @@ Test case 'URLTests/resolvingRedirectedLink()' passed (12.001 seconds)
 - If verification starts failing in weird ways after interrupted or concurrent
   builds, run `make clean` and retry.
 
+## Platform & API Standards
+
+- Target **iOS 26+ / Xcode 26+ / Swift 6.3** only. Use current SDK and SwiftUI APIs.
+- Prefer the latest framework patterns over legacy or deprecated approaches.
+- Do not add backwards-compatibility shims, `@available` fallbacks, or old API
+  workarounds unless the task explicitly asks for them.
+- Do not compromise on quality, correctness, or documentation for speed.
+- Public API changes should include the same level of inline docs as surrounding
+  code (usage examples, parameter docs, links where helpful).
+
 ## Repo-Specific Preferences
 
 - Keep fixes direct. Avoid wrappers or extra abstraction unless they are
   clearly required.
-- Preserve existing public API shape when possible.
+- Breaking API or behavior changes are acceptable when they improve correctness
+  or modernity. Do not preserve legacy behavior by default.
 - For SwiftUI and concurrency warnings, prefer a minimal fix that matches the
   framework API contract instead of adding unsafe workarounds.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Platform & API Standards** to `AGENTS.md` and updates repo preferences to match:

- Latest iOS 26 / Xcode 26 / Swift 6.3 and SwiftUI APIs
- No backwards-compatibility shims unless explicitly requested
- Quality, correctness, and documentation are not optional
- Breaking changes are acceptable when they improve correctness or modernity

Replaces the previous "preserve existing public API shape when possible" guidance, which conflicted with the no-backwards-compat default.

## Test plan

- [x] Documentation only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

