### PR TITLE
Replace AnyCodable with in-repo JSONValue for CodingFormatStyle

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "originHash" : "3d82051d5c092ebb03e512422474151d5ce6fd1d0863c36961c536bb7adf8376",
   "pins" : [
     {
-      "identity" : "anycodable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/zmian/AnyCodable",
-      "state" : {
-        "branch" : "master",
-        "revision" : "ca1a7d64fd7584fb0e3d4de521c76e2969b8ded6"
-      }
-    },
-    {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.21.7"),
-        .package(url: "https://github.com/zmian/AnyCodable", branch: "master"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", from: "4.2.2"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.12.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")
@@ -20,7 +19,6 @@ let package = Package(
             name: "Xcore",
             dependencies: [
                 "SDWebImage",
-                "AnyCodable",
                 "KeychainAccess",
                 .product(name: "Dependencies", package: "swift-dependencies")
             ],

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Bool.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Bool.swift
@@ -13,8 +13,8 @@ public struct BoolCodingFormatStyle: CodingFormatStyle, Sendable {
         self.encodeAsString = encodeAsString
     }
 
-    public func decode(_ value: AnyCodable) throws -> Bool {
-        let value = value.value
+    public func decode(_ value: JSONValue) throws -> Bool {
+        let value = value.anyValue
 
         if let value = value as? Bool {
             return value
@@ -25,12 +25,12 @@ public struct BoolCodingFormatStyle: CodingFormatStyle, Sendable {
         }
     }
 
-    public func encode(_ value: Bool) throws -> AnyCodable {
+    public func encode(_ value: Bool) throws -> JSONValue {
         if encodeAsString {
-            return AnyCodable(value ? "true" : "false")
+            return JSONValue(value ? "true" : "false")
         }
 
-        return AnyCodable(value)
+        return JSONValue(value)
     }
 }
 

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Decimal.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Decimal.swift
@@ -14,8 +14,8 @@ public struct DecimalCodingFormatStyle: CodingFormatStyle, Sendable {
         self.encodeAsString = encodeAsString
     }
 
-    public func decode(_ value: AnyCodable) throws -> Decimal {
-        let value = value.value
+    public func decode(_ value: JSONValue) throws -> Decimal {
+        let value = value.anyValue
 
         if let value = value as? Decimal {
             return value
@@ -31,8 +31,8 @@ public struct DecimalCodingFormatStyle: CodingFormatStyle, Sendable {
         throw CodingFormatStyleError.invalidValue
     }
 
-    public func encode(_ value: Decimal) throws -> AnyCodable {
-        AnyCodable.from(encodeAsString ? value.stringValue : value)
+    public func encode(_ value: Decimal) throws -> JSONValue {
+        JSONValue.from(encodeAsString ? value.stringValue : value)
     }
 }
 

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Double.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Double.swift
@@ -14,8 +14,8 @@ public struct DoubleCodingFormatStyle: CodingFormatStyle, Sendable {
         self.encodeAsString = encodeAsString
     }
 
-    public func decode(_ value: AnyCodable) throws -> Double {
-        let value = value.value
+    public func decode(_ value: JSONValue) throws -> Double {
+        let value = value.anyValue
 
         if let value = value as? Double {
             return value
@@ -35,8 +35,8 @@ public struct DoubleCodingFormatStyle: CodingFormatStyle, Sendable {
         )
     }
 
-    public func encode(_ value: Double) throws -> AnyCodable {
-        AnyCodable.from(encodeAsString ? value.stringValue : value)
+    public func encode(_ value: Double) throws -> JSONValue {
+        JSONValue.from(encodeAsString ? value.stringValue : value)
     }
 }
 

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Int.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Int.swift
@@ -13,8 +13,8 @@ public struct IntCodingFormatStyle: CodingFormatStyle, Sendable {
         self.encodeAsString = encodeAsString
     }
 
-    public func decode(_ value: AnyCodable) throws -> Int {
-        let value = value.value
+    public func decode(_ value: JSONValue) throws -> Int {
+        let value = value.anyValue
 
         if let value = value as? Int {
             return value
@@ -27,8 +27,8 @@ public struct IntCodingFormatStyle: CodingFormatStyle, Sendable {
         return try Int(value, format: .number.locale(.usPosix))
     }
 
-    public func encode(_ value: Int) throws -> AnyCodable {
-        AnyCodable.from(encodeAsString ? String(format: "%i", value) : value)
+    public func encode(_ value: Int) throws -> JSONValue {
+        JSONValue.from(encodeAsString ? String(format: "%i", value) : value)
     }
 }
 

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Map.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+Map.swift
@@ -14,8 +14,8 @@ public struct MapDecodingFormatStyle<Output>: DecodingFormatStyle, Sendable {
         self.decode = decode
     }
 
-    public func decode(_ value: AnyCodable) throws -> Output {
-        guard let result = try decode(value.value) else {
+    public func decode(_ value: JSONValue) throws -> Output {
+        guard let result = try decode(value.anyValue) else {
             throw CodingFormatStyleError.invalidValue
         }
 

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+RawRepresentable.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+RawRepresentable.swift
@@ -20,11 +20,11 @@ public struct RawRepresentableDecodingFormatStyle<Output>: DecodingFormatStyle, 
         self.options = options
     }
 
-    public func decode(_ value: AnyCodable) throws -> Output {
+    public func decode(_ value: JSONValue) throws -> Output {
         // Attempt to construct the value from the given value without any
         // transformation.
         if
-            let value = value.value as? Output.RawValue,
+            let value = value.anyValue as? Output.RawValue,
             let output = Output(rawValue: value)
         {
             return output

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+String.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+String.swift
@@ -40,8 +40,8 @@ public struct StringCodingFormatStyle: CodingFormatStyle, Sendable {
         self.options = options
     }
 
-    public func decode(_ value: AnyCodable) throws -> String {
-        let value = value.value
+    public func decode(_ value: JSONValue) throws -> String {
+        let value = value.anyValue
         let result: String
 
         if let value = value as? String {
@@ -55,8 +55,8 @@ public struct StringCodingFormatStyle: CodingFormatStyle, Sendable {
         return try applyOptions(to: result)
     }
 
-    public func encode(_ value: String) throws -> AnyCodable {
-        AnyCodable(try applyOptions(to: value))
+    public func encode(_ value: String) throws -> JSONValue {
+        JSONValue(try applyOptions(to: value))
     }
 
     private func applyOptions(to value: String) throws -> String {

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+StringMap.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+StringMap.swift
@@ -16,9 +16,9 @@ public struct StringMapDecodingFormatStyle<Output>: DecodingFormatStyle, Sendabl
         self.decode = decode
     }
 
-    public func decode(_ value: AnyCodable) throws -> Output {
+    public func decode(_ value: JSONValue) throws -> Output {
         guard
-            let value = value.value as? String,
+            let value = value.anyValue as? String,
             let result = try decode(value)
         else {
             throw CodingFormatStyleError.invalidValue

--- a/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+URL.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/FormatStyle/CodingFormatStyle+URL.swift
@@ -13,13 +13,13 @@ public struct URLCodingFormatStyle: CodingFormatStyle, Sendable {
         self.allowedCharacters = allowedCharacters
     }
 
-    public func decode(_ value: AnyCodable) throws -> URL {
-        if let value = value.value as? URL {
+    public func decode(_ value: JSONValue) throws -> URL {
+        if let value = value.anyValue as? URL {
             return value
         }
 
         guard
-            let value = value.value as? String,
+            let value = value.anyValue as? String,
             let value = value.removingPercentEncoding,
             !value.isBlank
         else {
@@ -41,8 +41,8 @@ public struct URLCodingFormatStyle: CodingFormatStyle, Sendable {
         throw CodingFormatStyleError.invalidValue
     }
 
-    public func encode(_ value: URL) throws -> AnyCodable {
-        AnyCodable(value.absoluteString)
+    public func encode(_ value: URL) throws -> JSONValue {
+        JSONValue(value.absoluteString)
     }
 }
 

--- a/Sources/Xcore/Swift/Extensions/Codable/JSONValue.swift
+++ b/Sources/Xcore/Swift/Extensions/Codable/JSONValue.swift
@@ -1,0 +1,195 @@
+//
+// Xcore
+// Copyright © 2026 Xcore
+// MIT license, see LICENSE file for details
+//
+
+import Foundation
+
+/// A JSON leaf or container value used by ``CodingFormatStyle``.
+///
+/// This type is not re-exported from Xcore. Prefer ``KeyedDecodingContainer`` and
+/// ``KeyedEncodingContainer`` format-style APIs instead of using this type directly.
+public struct JSONValue: Codable, Sendable, Equatable {
+    enum Kind: Equatable {
+        case null
+        case bool(Bool)
+        case int(Int)
+        case uint(UInt)
+        case double(Double)
+        case string(String)
+        case array([JSONValue])
+        case object([String: JSONValue])
+    }
+
+    var kind: Kind
+
+    init(_ value: (some Sendable)?) {
+        kind = Self.makeKind(from: value ?? ())
+    }
+
+    static func from(_ value: some Sendable) -> Self {
+        Self(value)
+    }
+
+    /// The underlying value used by flexible format styles such as ``MapDecodingFormatStyle``.
+    var anyValue: Any {
+        switch kind {
+            case .null:
+                NSNull()
+            case let .bool(value):
+                value
+            case let .int(value):
+                value
+            case let .uint(value):
+                value
+            case let .double(value):
+                value
+            case let .string(value):
+                value
+            case let .array(values):
+                values.map(\.anyValue)
+            case let .object(values):
+                values.mapValues(\.anyValue)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            kind = .null
+        } else if let string = try? container.decode(String.self) {
+            kind = .string(string)
+        } else if let int = try? container.decode(Int.self) {
+            kind = .int(int)
+        } else if let uint = try? container.decode(UInt.self) {
+            kind = .uint(uint)
+        } else if let double = try? container.decode(Double.self) {
+            kind = .double(double)
+        } else if let bool = try? container.decode(Bool.self) {
+            kind = .bool(bool)
+        } else if let array = try? container.decode([JSONValue].self) {
+            kind = .array(array)
+        } else if let object = try? container.decode([String: JSONValue].self) {
+            kind = .object(object)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "JSONValue cannot be decoded"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch kind {
+            case .null:
+                try container.encodeNil()
+            case let .bool(value):
+                try container.encode(value)
+            case let .int(value):
+                try container.encode(value)
+            case let .uint(value):
+                try container.encode(value)
+            case let .double(value):
+                try container.encode(value)
+            case let .string(value):
+                try container.encode(value)
+            case let .array(values):
+                try container.encode(values)
+            case let .object(values):
+                try container.encode(values)
+        }
+    }
+
+    private static func makeKind(from value: Any) -> Kind {
+        switch value {
+            case is Void:
+                .null
+            case is NSNull:
+                .null
+            case let value as Bool:
+                .bool(value)
+            case let value as Int:
+                .int(value)
+            case let value as Int8:
+                .int(Int(value))
+            case let value as Int16:
+                .int(Int(value))
+            case let value as Int32:
+                .int(Int(value))
+            case let value as Int64:
+                .int(Int(value))
+            case let value as UInt:
+                .uint(value)
+            case let value as UInt8:
+                .uint(UInt(value))
+            case let value as UInt16:
+                .uint(UInt(value))
+            case let value as UInt32:
+                .uint(UInt(value))
+            case let value as UInt64:
+                .uint(UInt(value))
+            case let value as Float:
+                .double(Double(value))
+            case let value as Double:
+                .double(value)
+            case let value as Decimal:
+                fromEncodable(value).kind
+            case let value as String:
+                .string(value)
+            case let value as URL:
+                .string(value.absoluteString)
+            case let value as [Any?]:
+                .array(value.map { JSONValue($0) })
+            case let value as [Any]:
+                .array(value.map { JSONValue($0) })
+            case let value as [String: Any?]:
+                .object(value.mapValues { JSONValue($0) })
+            case let value as [String: Any]:
+                .object(value.mapValues { JSONValue($0) })
+            case let value as Encodable:
+                fromEncodable(value).kind
+            default:
+                .string(String(describing: value))
+        }
+    }
+
+    private static func fromEncodable(_ value: Encodable) -> Self {
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(AnyEncodableBox(value)) else {
+            return JSONValue(kind: .string(String(describing: value)))
+        }
+
+        return (try? JSONDecoder().decode(JSONValue.self, from: data)) ?? JSONValue(kind: .string(String(describing: value)))
+    }
+
+    private init(kind: Kind) {
+        self.kind = kind
+    }
+}
+
+private struct AnyEncodableBox: Encodable {
+    let value: Encodable
+
+    init(_ value: Encodable) {
+        self.value = value
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
+extension JSONValue {
+    static var null: Self { JSONValue(kind: .null) }
+    static func bool(_ value: Bool) -> Self { JSONValue(kind: .bool(value)) }
+    static func int(_ value: Int) -> Self { JSONValue(kind: .int(value)) }
+    static func uint(_ value: UInt) -> Self { JSONValue(kind: .uint(value)) }
+    static func double(_ value: Double) -> Self { JSONValue(kind: .double(value)) }
+    static func string(_ value: String) -> Self { JSONValue(kind: .string(value)) }
+    static func array(_ value: [JSONValue]) -> Self { JSONValue(kind: .array(value)) }
+    static func object(_ value: [String: JSONValue]) -> Self { JSONValue(kind: .object(value)) }
+}

--- a/Sources/Xcore/Swift/Helpers/Xcore.swift
+++ b/Sources/Xcore/Swift/Helpers/Xcore.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-@_exported import AnyCodable
 @_exported import KeychainAccess
 @_exported import Dependencies
 
@@ -22,8 +21,3 @@ extension Bundle {
     }
 }
 
-extension AnyCodable {
-    public static func from(_ value: any Sendable) -> Self {
-        self.init(value)
-    }
-}

--- a/Tests/XcoreTests/Codable/JSONValueTests.swift
+++ b/Tests/XcoreTests/Codable/JSONValueTests.swift
@@ -1,0 +1,132 @@
+//
+// Xcore
+// Copyright © 2026 Xcore
+// MIT license, see LICENSE file for details
+//
+
+import Testing
+import Foundation
+@testable import Xcore
+
+struct JSONValueTests {
+    @Test
+    func decodesJSONPrimitives() throws {
+        let json = Data(
+            """
+            {
+                "null": null,
+                "bool": true,
+                "int": 42,
+                "double": 3.14,
+                "string": "hello",
+                "array": [1, "two", false],
+                "object": { "a": 1 }
+            }
+            """.utf8
+        )
+
+        struct Payload: Decodable {
+            let null: JSONValue
+            let bool: JSONValue
+            let int: JSONValue
+            let double: JSONValue
+            let string: JSONValue
+            let array: JSONValue
+            let object: JSONValue
+        }
+
+        let payload = try JSONDecoder().decode(Payload.self, from: json)
+
+        #expect(payload.null == JSONValue.null)
+        #expect(payload.bool == JSONValue.bool(true))
+        #expect(payload.int == JSONValue.int(42))
+        #expect(payload.double == JSONValue.double(3.14))
+        #expect(payload.string == JSONValue.string("hello"))
+        #expect(payload.array == JSONValue.array([JSONValue.int(1), JSONValue.string("two"), JSONValue.bool(false)]))
+        #expect(payload.object == JSONValue.object(["a": JSONValue.int(1)]))
+    }
+
+    @Test
+    func encodesJSONPrimitives() throws {
+        let value: [String: JSONValue] = [
+            "null": JSONValue.null,
+            "bool": JSONValue.bool(false),
+            "int": JSONValue.int(7),
+            "double": JSONValue.double(1.5),
+            "string": JSONValue.string("world"),
+            "array": JSONValue.array([JSONValue.string("a")]),
+            "object": JSONValue.object(["key": JSONValue.bool(true)])
+        ]
+
+        let decoded = try JSONDecoder().decode([String: JSONValue].self, from: try JSONEncoder().encode(value))
+
+        #expect(decoded == value)
+    }
+
+    @Test
+    func fromSendableValues() {
+        #expect(JSONValue.from(true) == JSONValue.bool(true))
+        #expect(JSONValue.from(123) == JSONValue.int(123))
+        #expect(JSONValue.from(1.25) == JSONValue.double(1.25))
+        #expect(JSONValue.from("text") == JSONValue.string("text"))
+    }
+
+    @Test
+    func fromDecimalValue() throws {
+        let decimal = try #require(Decimal(string: "9.99", locale: .us))
+        let decoded = try DecimalCodingFormatStyle().decode(JSONValue.from(decimal))
+
+        #expect(decoded == decimal)
+    }
+
+    @Test
+    func anyValueMatchesJSONTypes() {
+        #expect(JSONValue.null.anyValue is NSNull)
+        #expect(JSONValue.bool(true).anyValue as? Bool == true)
+        #expect(JSONValue.int(10).anyValue as? Int == 10)
+        #expect(JSONValue.string("x").anyValue as? String == "x")
+    }
+
+    @Test
+    func decodeOrderMatchesStringBeforeNumber() throws {
+        let stringValue = try JSONDecoder().decode(JSONValue.self, from: Data(#""123""#.utf8))
+        let intValue = try JSONDecoder().decode(JSONValue.self, from: Data("123".utf8))
+
+        #expect(stringValue == JSONValue.string("123"))
+        #expect(intValue == JSONValue.int(123))
+    }
+
+    @Test
+    func roundTripThroughFormatStyleContainer() throws {
+        struct Example: Codable, Equatable {
+            enum CodingKeys: CodingKey {
+                case value
+            }
+
+            let value: Int
+
+            init(value: Int) {
+                self.value = value
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                value = try container.decode(.value, format: .int)
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(value, forKey: .value, format: .int)
+            }
+        }
+
+        let fromNumber = try JSONDecoder().decode(Example.self, from: Data(#"{"value": 5}"#.utf8))
+        let fromString = try JSONDecoder().decode(Example.self, from: Data(#"{"value": "5"}"#.utf8))
+        let encoded = try JSONEncoder().encode(Example(value: 5))
+        let roundTrip = try JSONDecoder().decode(Example.self, from: encoded)
+
+        #expect(fromNumber.value == 5)
+        #expect(fromString.value == 5)
+        #expect(roundTrip.value == 5)
+    }
+}

--- a/Xcore.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Xcore.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,15 +2,6 @@
   "originHash" : "f4a778e2b00a216eec95a998607f36b1dc2a7ead6d7e2790b30dd6816504d850",
   "pins" : [
     {
-      "identity" : "anycodable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/zmian/AnyCodable",
-      "state" : {
-        "branch" : "master",
-        "revision" : "82d26c99f4f5150b5d2c7aebb8cb84c997fb2343"
-      }
-    },
-    {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the external `AnyCodable` dependency with an in-repo `JSONValue` type used by `CodingFormatStyle`.

- Adds `JSONValue` with AnyCodable-compatible JSON decode order (nil → string → int → uint → double → bool → array → object)
- Preserves flexible format-style behavior via `anyValue` (including `MapDecodingFormatStyle` and numeric/string coercion paths)
- Updates all polymorphic format styles to use `JSONValue`
- Removes `@_exported import AnyCodable` and the `zmian/AnyCodable` package dependency
- Adds `JSONValueTests`
- Leaves `CodingFormatStyleTests` unchanged

## Breaking changes

- `@_exported import AnyCodable` is removed. Consumers that relied on transitive `AnyCodable` must import/add their own dependency.
- `CodingFormatStyle` wire type is now `JSONValue` instead of `AnyCodable` (same role, different type).

## Notes on visibility

`JSONValue` is a public struct because Swift requires the `CodingFormatStyle` protocol witness types to be visible. Its storage enum remains module-internal, and the type is not re-exported from `Xcore.swift`.

## Test plan

- [ ] `make test TEST_ONLY=XcoreTests/JSONValueTests`
- [ ] `make test TEST_ONLY=XcoreTests/CodingFormatStyleTests`
- [ ] `make build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

