### PR TITLE
Document AnyCodable policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS
 
-This repo is an iOS 26+ / Xcode 26+ / Swift 6.3 package plus example app.
+This repo targets the latest iOS, Xcode, and Swift releases plus an example app.
 
 ## Verification
 
@@ -29,7 +29,7 @@ and uses `Xcore.xcworkspace` + the `Example` scheme. That is the supported path.
 
 ## Code Standards
 
-- Use current iOS 26 / Xcode 26 / Swift 6.3 SDK and SwiftUI APIs.
+- Use the latest iOS, Xcode, Swift, and SwiftUI APIs.
 - Do not add backwards-compatibility shims, `@available` fallbacks, or legacy API
   workarounds unless explicitly requested.
 - Keep fixes direct. Add abstraction only when it removes real complexity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,34 +1,106 @@
 # AGENTS
 
-iOS 26+ / Xcode 26+ Swift package + Example app. Use the Makefile and
-`Xcore.xcworkspace` — not ad-hoc `swift` / `xcodebuild` commands.
+These notes are for agents working in this repository.
 
-## Verify
+The repo is an iOS 26+ / Xcode 26+ Swift package plus example app. Prefer the
+repo Makefile and workspace-based Xcode flow over ad-hoc commands.
 
-```bash
-make build          # compile
-make test           # full suite
-make test TEST_ONLY=XcoreTests/SomeTests/someTest
-make lint
-make format
-make clean          # if builds act weird
-```
+## Primary Verification Path
 
-- Use `make build` for compile/API changes; `make test TEST_ONLY=...` only for
-  relevant tests. Not `swift test`.
-- Tests run via `Example` scheme in `Xcore.xcworkspace`, not the `Xcore` scheme.
-- Do not run parallel `make` / `xcodebuild` on the same checkout.
+Use the Makefile from the repo root.
+
+- `make build`
+  Builds the `Example` scheme in `Xcore.xcworkspace`.
+- `make test`
+  Runs the full test suite through the `Example` scheme.
+- `make test TEST_ONLY=XcoreTests/SomeTests/someTest`
+  Runs a single targeted test.
+- `make run`
+  Builds, installs, and launches the example app in the configured simulator.
+- `make clean`
+  Clears derived data and repo-local workspace state used by the Make targets.
+- `make lint`
+  Runs SwiftLint.
+- `make format`
+  Runs SwiftFormat.
+
+## Verification Rules
+
+- Prefer `make build` for compile errors, warnings, and API-shape changes that
+  are not tied to one specific test.
+- Prefer `make test TEST_ONLY=...` only when the test is directly relevant to
+  the behavior being changed.
+- Do not use an unrelated test target as a proxy just because it is convenient.
+- Prefer `make test` over `swift test` for real verification in this repo.
 - No Xcode in your environment? Say so and give the exact `make` commands to run.
 
-## Code
+## Why Makefile First
 
-- iOS 26 / Xcode 26 / Swift 6.3 only. Current APIs. No backwards-compat shims
-  unless asked.
-- Direct fixes. Match existing docs for public API changes.
-- Breaking changes OK when asked or clearly better. No legacy preservation by default.
+- The Makefile forces `DEVELOPER_DIR` to `/Applications/Xcode.app/Contents/Developer`.
+  This matters on machines where `xcode-select` points at Command Line Tools.
+- Tests run through `Xcore.xcworkspace` and the `Example` scheme.
+- The `Xcore` scheme is not the correct default verification path for tests.
+- `swift test` is not the reliable fallback for this repo.
 
-## Do not suggest
+## Test Output Notes
 
-- Splitting Xcore into submodules (one target by design; folders are enough).
-- Replacing, pinning, or removing `@_exported import AnyCodable` (`zmian/AnyCodable`
-  `master` fork — intentional for `CodingFormatStyle`).
+- `make test` uses `xcodebuild test -quiet`.
+- This suppresses Xcode boilerplate such as package-resolution chatter and
+  command invocation noise.
+- Test progress is intentionally preserved.
+- The Makefile also strips known Xcode metadata noise such as:
+  `[MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.`
+- Test lines are normalized to remove simulator-specific suffixes while keeping
+  the suite/test name and duration.
+
+Example:
+
+```text
+Test suite 'URLTests' started
+Test case 'URLTests/resolvingRedirectedLink()' passed (12.001 seconds)
+```
+
+## Concurrency / Execution Notes
+
+- Do not run multiple `make` or `xcodebuild` verification commands in parallel
+  against the same checkout.
+- Parallel runs can corrupt or confuse package-resolution and derived-data state.
+- If verification starts failing in weird ways after interrupted or concurrent
+  builds, run `make clean` and retry.
+
+## Platform & API Standards
+
+- Target **iOS 26+ / Xcode 26+ / Swift 6.3** only. Use current SDK and SwiftUI APIs.
+- Prefer the latest framework patterns over legacy or deprecated approaches.
+- Do not add backwards-compatibility shims, `@available` fallbacks, or old API
+  workarounds unless the task explicitly asks for them.
+- Do not compromise on quality, correctness, or documentation for speed.
+- Public API changes should include the same level of inline docs as surrounding
+  code (usage examples, parameter docs, links where helpful).
+
+## Repo-Specific Preferences
+
+- Keep fixes direct. Avoid wrappers or extra abstraction unless they are
+  clearly required.
+- Breaking API or behavior changes are acceptable when they improve correctness
+  or modernity. Do not preserve legacy behavior by default.
+- For SwiftUI and concurrency warnings, prefer a minimal fix that matches the
+  framework API contract instead of adding unsafe workarounds.
+
+## Package Layout
+
+Xcore is one Swift package target: `import Xcore`. Folders (`Swift/`, `SwiftUI/`,
+`Cocoa/`) organize code; they are not separate modules.
+
+- Do not propose splitting into submodules as a default refactor.
+- Builds are fast enough for this repo; link-time dead code stripping keeps
+  unused APIs out of app binaries.
+- Revisit splitting only for measured build-time pain or an explicit new public
+  product requirement.
+
+## AnyCodable
+
+- Keep `zmian/AnyCodable` on `master`. Do not pin it unless asked.
+- Do not replace it with an in-repo type (e.g. `JSONValue`) or rework
+  `CodingFormatStyle` unless asked.
+- Do not remove `@_exported import AnyCodable` from `Xcore.swift`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ and uses `Xcore.xcworkspace` + the `Example` scheme. That is the supported path.
 - Xcore is one Swift package target: `import Xcore`. Folders (`Swift/`,
   `SwiftUI/`, `Cocoa/`) are organization only. Do not propose submodule splits
   unless asked or backed by measured build-time pain.
-- Keep `zmian/AnyCodable` on `master`. Do not pin it, replace it with `JSONValue`,
-  remove `@_exported import AnyCodable`, or rework `CodingFormatStyle` unless
-  explicitly requested.
+- Keep `zmian/AnyCodable` on `master`. Do not pin it, replace it with an in-repo
+  type, remove `@_exported import AnyCodable`, or rework `CodingFormatStyle`
+  unless a built-in Swift/Foundation feature is clearly better than the current
+  AnyCodable implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,106 +1,49 @@
 # AGENTS
 
-These notes are for agents working in this repository.
+This repo is an iOS 26+ / Xcode 26+ / Swift 6.3 package plus example app.
 
-The repo is an iOS 26+ / Xcode 26+ Swift package plus example app. Prefer the
-repo Makefile and workspace-based Xcode flow over ad-hoc commands.
+## Verification
 
-## Primary Verification Path
+Run verification from the repo root through the Makefile. Do not use `swift test`
+or ad-hoc `xcodebuild`.
 
-Use the Makefile from the repo root.
+- `make build` — compile the `Example` scheme in `Xcore.xcworkspace`.
+- `make test` — run the full suite through the `Example` scheme.
+- `make test TEST_ONLY=XcoreTests/SomeTests/someTest` — run one relevant test.
+- `make run` — build, install, and launch the example app.
+- `make lint` / `make format` — SwiftLint / SwiftFormat.
+- `make clean` — reset derived data and repo-local build state.
 
-- `make build`
-  Builds the `Example` scheme in `Xcore.xcworkspace`.
-- `make test`
-  Runs the full test suite through the `Example` scheme.
-- `make test TEST_ONLY=XcoreTests/SomeTests/someTest`
-  Runs a single targeted test.
-- `make run`
-  Builds, installs, and launches the example app in the configured simulator.
-- `make clean`
-  Clears derived data and repo-local workspace state used by the Make targets.
-- `make lint`
-  Runs SwiftLint.
-- `make format`
-  Runs SwiftFormat.
+Rules:
 
-## Verification Rules
+- Use `make build` for compile errors, warnings, and API-shape changes.
+- Use `make test TEST_ONLY=...` only for tests directly tied to the change.
+- Do not use unrelated tests as a proxy.
+- Do not run multiple `make` / `xcodebuild` jobs in the same checkout.
+- If verification fails strangely after interruption or concurrency, run
+  `make clean` and retry.
+- If Xcode is unavailable, say so and list the exact `make` commands to run.
 
-- Prefer `make build` for compile errors, warnings, and API-shape changes that
-  are not tied to one specific test.
-- Prefer `make test TEST_ONLY=...` only when the test is directly relevant to
-  the behavior being changed.
-- Do not use an unrelated test target as a proxy just because it is convenient.
-- Prefer `make test` over `swift test` for real verification in this repo.
-- No Xcode in your environment? Say so and give the exact `make` commands to run.
+The Makefile sets `DEVELOPER_DIR` to `/Applications/Xcode.app/Contents/Developer`
+and uses `Xcore.xcworkspace` + the `Example` scheme. That is the supported path.
 
-## Why Makefile First
+## Code Standards
 
-- The Makefile forces `DEVELOPER_DIR` to `/Applications/Xcode.app/Contents/Developer`.
-  This matters on machines where `xcode-select` points at Command Line Tools.
-- Tests run through `Xcore.xcworkspace` and the `Example` scheme.
-- The `Xcore` scheme is not the correct default verification path for tests.
-- `swift test` is not the reliable fallback for this repo.
+- Use current iOS 26 / Xcode 26 / Swift 6.3 SDK and SwiftUI APIs.
+- Do not add backwards-compatibility shims, `@available` fallbacks, or legacy API
+  workarounds unless explicitly requested.
+- Keep fixes direct. Add abstraction only when it removes real complexity.
+- Public API changes need docs matching nearby public API docs.
+- Breaking API or behavior changes are allowed when they improve correctness or
+  modernity. Do not preserve legacy behavior by default.
+- For SwiftUI and concurrency warnings, follow the framework API contract; do not
+  add unsafe workarounds.
 
-## Test Output Notes
+## Fixed Decisions
 
-- `make test` uses `xcodebuild test -quiet`.
-- This suppresses Xcode boilerplate such as package-resolution chatter and
-  command invocation noise.
-- Test progress is intentionally preserved.
-- The Makefile also strips known Xcode metadata noise such as:
-  `[MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.`
-- Test lines are normalized to remove simulator-specific suffixes while keeping
-  the suite/test name and duration.
-
-Example:
-
-```text
-Test suite 'URLTests' started
-Test case 'URLTests/resolvingRedirectedLink()' passed (12.001 seconds)
-```
-
-## Concurrency / Execution Notes
-
-- Do not run multiple `make` or `xcodebuild` verification commands in parallel
-  against the same checkout.
-- Parallel runs can corrupt or confuse package-resolution and derived-data state.
-- If verification starts failing in weird ways after interrupted or concurrent
-  builds, run `make clean` and retry.
-
-## Platform & API Standards
-
-- Target **iOS 26+ / Xcode 26+ / Swift 6.3** only. Use current SDK and SwiftUI APIs.
-- Prefer the latest framework patterns over legacy or deprecated approaches.
-- Do not add backwards-compatibility shims, `@available` fallbacks, or old API
-  workarounds unless the task explicitly asks for them.
-- Do not compromise on quality, correctness, or documentation for speed.
-- Public API changes should include the same level of inline docs as surrounding
-  code (usage examples, parameter docs, links where helpful).
-
-## Repo-Specific Preferences
-
-- Keep fixes direct. Avoid wrappers or extra abstraction unless they are
-  clearly required.
-- Breaking API or behavior changes are acceptable when they improve correctness
-  or modernity. Do not preserve legacy behavior by default.
-- For SwiftUI and concurrency warnings, prefer a minimal fix that matches the
-  framework API contract instead of adding unsafe workarounds.
-
-## Package Layout
-
-Xcore is one Swift package target: `import Xcore`. Folders (`Swift/`, `SwiftUI/`,
-`Cocoa/`) organize code; they are not separate modules.
-
-- Do not propose splitting into submodules as a default refactor.
-- Builds are fast enough for this repo; link-time dead code stripping keeps
-  unused APIs out of app binaries.
-- Revisit splitting only for measured build-time pain or an explicit new public
-  product requirement.
-
-## AnyCodable
-
-- Keep `zmian/AnyCodable` on `master`. Do not pin it unless asked.
-- Do not replace it with an in-repo type (e.g. `JSONValue`) or rework
-  `CodingFormatStyle` unless asked.
-- Do not remove `@_exported import AnyCodable` from `Xcore.swift`.
+- Xcore is one Swift package target: `import Xcore`. Folders (`Swift/`,
+  `SwiftUI/`, `Cocoa/`) are organization only. Do not propose submodule splits
+  unless asked or backed by measured build-time pain.
+- Keep `zmian/AnyCodable` on `master`. Do not pin it, replace it with `JSONValue`,
+  remove `@_exported import AnyCodable`, or rework `CodingFormatStyle` unless
+  explicitly requested.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,100 +1,34 @@
 # AGENTS
 
-## Scope
+iOS 26+ / Xcode 26+ Swift package + Example app. Use the Makefile and
+`Xcore.xcworkspace` — not ad-hoc `swift` / `xcodebuild` commands.
 
-These notes are for agents working in this repository.
+## Verify
 
-The repo is an iOS 26+ / Xcode 26+ Swift package plus example app. Prefer the
-repo Makefile and workspace-based Xcode flow over ad-hoc commands.
-
-## Primary Verification Path
-
-Use the Makefile from the repo root.
-
-- `make build`
-  Builds the `Example` scheme in `Xcore.xcworkspace`.
-- `make test`
-  Runs the full test suite through the `Example` scheme.
-- `make test TEST_ONLY=XcoreTests/SomeTests/someTest`
-  Runs a single targeted test.
-- `make run`
-  Builds, installs, and launches the example app in the configured simulator.
-- `make clean`
-  Clears derived data and repo-local workspace state used by the Make targets.
-- `make lint`
-  Runs SwiftLint.
-- `make format`
-  Runs SwiftFormat.
-
-## Verification Rules
-
-- Prefer `make build` for compile errors, warnings, and API-shape changes that
-  are not tied to one specific test.
-- Prefer `make test TEST_ONLY=...` only when the test is directly relevant to
-  the behavior being changed.
-- Do not use an unrelated test target as a proxy just because it is convenient.
-- Prefer `make test` over `swift test` for real verification in this repo.
-
-## Why Makefile First
-
-- The Makefile forces `DEVELOPER_DIR` to `/Applications/Xcode.app/Contents/Developer`.
-  This matters on machines where `xcode-select` points at Command Line Tools.
-- Tests run through `Xcore.xcworkspace` and the `Example` scheme.
-- The `Xcore` scheme is not the correct default verification path for tests.
-- `swift test` is not the reliable fallback for this repo.
-
-## Test Output Notes
-
-- `make test` uses `xcodebuild test -quiet`.
-- This suppresses Xcode boilerplate such as package-resolution chatter and
-  command invocation noise.
-- Test progress is intentionally preserved.
-- The Makefile also strips known Xcode metadata noise such as:
-  `[MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.`
-- Test lines are normalized to remove simulator-specific suffixes while keeping
-  the suite/test name and duration.
-
-Example:
-
-```text
-Test suite 'URLTests' started
-Test case 'URLTests/resolvingRedirectedLink()' passed (12.001 seconds)
+```bash
+make build          # compile
+make test           # full suite
+make test TEST_ONLY=XcoreTests/SomeTests/someTest
+make lint
+make format
+make clean          # if builds act weird
 ```
 
-## Concurrency / Execution Notes
+- Use `make build` for compile/API changes; `make test TEST_ONLY=...` only for
+  relevant tests. Not `swift test`.
+- Tests run via `Example` scheme in `Xcore.xcworkspace`, not the `Xcore` scheme.
+- Do not run parallel `make` / `xcodebuild` on the same checkout.
+- No Xcode in your environment? Say so and give the exact `make` commands to run.
 
-- Do not run multiple `make` or `xcodebuild` verification commands in parallel
-  against the same checkout.
-- Parallel runs can corrupt or confuse package-resolution and derived-data state.
-- If verification starts failing in weird ways after interrupted or concurrent
-  builds, run `make clean` and retry.
+## Code
 
-## Platform & API Standards
+- iOS 26 / Xcode 26 / Swift 6.3 only. Current APIs. No backwards-compat shims
+  unless asked.
+- Direct fixes. Match existing docs for public API changes.
+- Breaking changes OK when asked or clearly better. No legacy preservation by default.
 
-- Target **iOS 26+ / Xcode 26+ / Swift 6.3** only. Use current SDK and SwiftUI APIs.
-- Prefer the latest framework patterns over legacy or deprecated approaches.
-- Do not add backwards-compatibility shims, `@available` fallbacks, or old API
-  workarounds unless the task explicitly asks for them.
-- Do not compromise on quality, correctness, or documentation for speed.
-- Public API changes should include the same level of inline docs as surrounding
-  code (usage examples, parameter docs, links where helpful).
+## Do not suggest
 
-## Repo-Specific Preferences
-
-- Keep fixes direct. Avoid wrappers or extra abstraction unless they are
-  clearly required.
-- Breaking API or behavior changes are acceptable when they improve correctness
-  or modernity. Do not preserve legacy behavior by default.
-- For SwiftUI and concurrency warnings, prefer a minimal fix that matches the
-  framework API contract instead of adding unsafe workarounds.
-
-## Package Layout
-
-Xcore is one Swift package target: `import Xcore`. Folders (`Swift/`, `SwiftUI/`,
-`Cocoa/`) organize code; they are not separate modules.
-
-- Do not propose splitting into submodules as a default refactor.
-- Builds are fast enough for this repo; link-time dead code stripping keeps
-  unused APIs out of app binaries.
-- Revisit splitting only for measured build-time pain or an explicit new public
-  product requirement.
+- Splitting Xcore into submodules (one target by design; folders are enough).
+- Replacing, pinning, or removing `@_exported import AnyCodable` (`zmian/AnyCodable`
+  `master` fork — intentional for `CodingFormatStyle`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Deep-reviewed and tightened `AGENTS.md` to high-agency rules without dropping important context.

Kept:
- Makefile-only verification path
- Exact supported commands
- `Example` scheme + `Xcore.xcworkspace`
- `DEVELOPER_DIR` reason
- No parallel `make` / `xcodebuild`
- Latest iOS/Xcode/Swift/SwiftUI default, without hard-coded version numbers
- Single-target package decision
- AnyCodable policy, allowing replacement only for a clearly better built-in Swift/Foundation feature

Removed:
- Repeated Makefile rationale
- Test output transcript example
- Verbose explanatory sections that did not change agent behavior

## Test plan

- [x] Documentation only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f15f5-f1ed-73be-810d-f0f335db61e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

